### PR TITLE
chore: pin skuse-ui to major version @0 via jsDelivr

### DIFF
--- a/Resources/views/documentation.html.twig
+++ b/Resources/views/documentation.html.twig
@@ -4,12 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>API Documentation</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/skuse-ui@{{ skuse_ui_version }}/dist/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/skuse-ui@0/dist/style.css">
     <style>html, body, #skuse-ui { height: 100%; margin: 0; }</style>
 </head>
 <body>
     <div id="skuse-ui"></div>
-    <script src="https://cdn.jsdelivr.net/npm/skuse-ui@{{ skuse_ui_version }}/dist/skuse-ui.iife.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/skuse-ui@0/dist/skuse-ui.iife.js"></script>
     <script>
         SkuseUI.mount('#skuse-ui', {
             openApiUrl: '{{ open_api_url|escape('js') }}',

--- a/src/Controller/DocumentationController.php
+++ b/src/Controller/DocumentationController.php
@@ -2,7 +2,6 @@
 
 namespace Piairre\Skuse\Controller;
 
-use Piairre\Skuse\PiairreSkuseBundle;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -19,7 +18,6 @@ class DocumentationController extends AbstractController
         return $this->render('@PiairreSkuse/documentation.html.twig', [
             'open_api_url' => $this->openApiUrl,
             'theme' => $this->theme,
-            'skuse_ui_version' => PiairreSkuseBundle::SKUSE_UI_VERSION,
         ]);
     }
 }

--- a/src/PiairreSkuseBundle.php
+++ b/src/PiairreSkuseBundle.php
@@ -8,8 +8,6 @@ use Piairre\Skuse\DependencyInjection\PiairreSkuseExtension;
 
 class PiairreSkuseBundle extends Bundle
 {
-    public const SKUSE_UI_VERSION = '0.1.5';
-
     public function getPath(): string
     {
         return dirname(__DIR__);


### PR DESCRIPTION
Remove SKUSE_UI_VERSION constant and hardcoded version from CDN URLs, using @0 semver range instead so patch/minor releases are picked up automatically without touching the PHP bundle.